### PR TITLE
Fixes #1: App Crashes using Anvil 0.2.0

### DIFF
--- a/library/src/main/java/trikita/anvil/RenderableRecyclerViewAdapter.java
+++ b/library/src/main/java/trikita/anvil/RenderableRecyclerViewAdapter.java
@@ -24,9 +24,9 @@ public abstract class RenderableRecyclerViewAdapter
                     RenderableRecyclerViewAdapter.this.view(h);
                 }
             });
-            h.mount.render();
+            Anvil.render(h.mount);
         } else {
-            h.mount.render();
+            Anvil.render(h.mount);
         }
     }
 


### PR DESCRIPTION
## Scope

Fix App crashes using Anvil-RecyclerView with Anvil 0.2.0
## Implementation

There was a subtle difference in the way the Mount class worked in previous versions of Anvil, and the latest Anvil 0.2.0.

In previous versions of Anvil, the `Mount` class' `render` method set the `currentMount` field of Anvil itself. The `currentMount` field is needed by the `Renderable.view` method, and if `currentMount` is `null`, a `NullPointerException` will be thrown. That's exactly what was happening here.

Since Anvil 0.2.0 no longer sets `currentMount` in the `Mount` render method, we must find an alternative way to solve the problem. Luckily, it appears as though a static helper method, `render(Mount m)` was put in place for this exact reason.

...And that's the back story on a 2-line PR :)
